### PR TITLE
Changed the delimiter in repo name sent in by pubsub messahe - to _

### DIFF
--- a/github-status/index.js
+++ b/github-status/index.js
@@ -37,8 +37,9 @@ module.exports.updateBuildStatus = (event) => {
   }
 
   let i, j = 0
-  i = repoSource.repoName.indexOf('_')
-  j = repoSource.repoName.indexOf('_', i + 1)
+  const delimiter = repoSource.repoName.startsWith('github_') ? '_' : '-';
+  i = repoSource.repoName.indexOf(delimiter)
+  j = repoSource.repoName.indexOf(delimiter, i + 1)
   const repoOwner = repoSource.repoName.substring(i + 1, j)
   const repoName = repoSource.repoName.substring(j + 1)
   if (!repoOwner || !repoName) {

--- a/github-status/index.js
+++ b/github-status/index.js
@@ -37,8 +37,8 @@ module.exports.updateBuildStatus = (event) => {
   }
 
   let i, j = 0
-  i = repoSource.repoName.indexOf('-')
-  j = repoSource.repoName.indexOf('-', i + 1)
+  i = repoSource.repoName.indexOf('_')
+  j = repoSource.repoName.indexOf('_', i + 1)
   const repoOwner = repoSource.repoName.substring(i + 1, j)
   const repoName = repoSource.repoName.substring(j + 1)
   if (!repoOwner || !repoName) {


### PR DESCRIPTION
The cloud function code gave exception ```Invalid repo info: github_neilghosh_speechtest``` while parsing the repo to fetch the owner and repo name. The current delimiter is an underscore instead of a dash which code was expecting